### PR TITLE
Tweaked the script to prefix all single char variables with `o`

### DIFF
--- a/Material Scanner/In-Universe_Edition.yolol
+++ b/Material Scanner/In-Universe_Edition.yolol
@@ -1,10 +1,10 @@
 j="\nMat|Stacks" o=j a=" Ore" b="\n" d="#" e="~" h="ium" TO=20
-:autoscan-=s s=e :autoscan=s+:autoscan f=1728000 :Re=1 :L=0 goto2+:AS
-:autoscan-=s s=d :autoscan=s+:autoscan g="ite" i=0 :I=0 :L=1 :R=0 :S=1
-tv=0 o=j c=" Crystal" i++ if i>TO then :L=0 goto9 end goto5-:S
-:L=0 i/=:R :I=0 v=:V/f*1000 tv+=v o+=b+"1 "+(:M-a-c-g-h)+"|"+v
-i/=:R :I=1 v=:V/f*1000 tv+=v o+=b+"2 "+(:M-a-c-g-h)+"|"+v
-i/=:R v=tv at="\nCLass:"+(4+v>10+v>11+v>18+v>26+v>124+v>270)
-i/=:R :autoscan=s+o+b+"Total Stacks:"+tv+at :S=0 :Re=1 goto2+:AS
-w="\n !WARNING!" i/=:R :autoscan=s+w+"\n\n «TIMEOUT»\n"+w goto2+:AS
-:autoscan=s+w+"\n\n  Nothing\n   Found\n"+w goto2+:AS 
+:scans-=s s=e :scans=s+:scans f=1728000 :Reset=1 :OL=0 goto2+:OT
+:scans-=s s=d :scans=s+:scans g="ite" i=0 :OI=0 :OL=1 :OX=0 :OS=1
+tv=0 o=j c=" Crystal" i++ if i>TO then :OL=0 goto9 end goto5-:OS
+:OL=0 i/=:OX :OI=0 v=:OV/f*1000 tv+=v o+=b+"1 "+(:OM-a-c-g-h)+"|"+v
+i/=:OX :OI=1 v=:OV/f*1000 tv+=v o+=b+"2 "+(:OM-a-c-g-h)+"|"+v
+i/=:OX v=tv at="\nCLass:"+(4+v>10+v>11+v>18+v>26+v>124+v>270)
+i/=:OX :scans=s+o+b+"Total Stacks:"+tv+at :OS=0 :Reset=1 goto2+:OT
+w="\n !WARNING!" i/=:OX :scans=s+w+"\n\n «TIMEOUT»\n"+w goto2+:OT
+:scans=s+w+"\n\n  Nothing\n   Found\n"+w goto2+:OT 

--- a/Material Scanner/README.md
+++ b/Material Scanner/README.md
@@ -45,13 +45,13 @@ I recommend a setup like this for your text panel, button and optional progress 
 
 |Default Name|New Name|Default Value|New Value|
 |-|-|-|-|                        
-|Active|L|0|0|
-|Index|I|0|0|
-|ScanResults|R|0|0|
-|Material|M|""|""|
-|Volume|V|0|0|
-|Scan|S|0|0|
-|Reset|Re|0|0|
+|Active|OL|0|0|
+|Index|OI|0|0|
+|ScanResults|OR|0|0|
+|Material|OM|""|""|
+|Volume|OV|0|0|
+|Scan|OS|0|0|
+Reset remains the same
 ##
 
 ### Basic YOLOL Chip:
@@ -63,14 +63,14 @@ I recommend a setup like this for your text panel, button and optional progress 
 ### Text Panel 24x24:
 |Default Name|New Name|Default Value|New Value|
 |-|-|-|-|                        
-|PanelValue|AutoScan|""|""|
+|PanelValue|Scan|""|""|
 |PanelVariableResolution|PanelVariableResolution|1|1|
 ##
 
 ### Button:
 |Default Name|New Name|Default Value|New Value|
 |-|-|-|-|                        
-|ButtonState|AS|0|0|
+|ButtonState|OT|0|0|
 |ButtonOnStateValue|ButtonOnStateValue|1|1|
 |ButtonOffStateValue|ButtonOffStateValue|0|0|
 |ButtonStyle|ButtonStyle|0|1|

--- a/Material Scanner/README.md
+++ b/Material Scanner/README.md
@@ -47,7 +47,7 @@ I recommend a setup like this for your text panel, button and optional progress 
 |-|-|-|-|                        
 |Active|OL|0|0|
 |Index|OI|0|0|
-|ScanResults|OR|0|0|
+|ScanResults|OX|0|0|
 |Material|OM|""|""|
 |Volume|OV|0|0|
 |Scan|OS|0|0|
@@ -63,7 +63,7 @@ Reset remains the same
 ### Text Panel 24x24:
 |Default Name|New Name|Default Value|New Value|
 |-|-|-|-|                        
-|PanelValue|Scan|""|""|
+|PanelValue|Scans|""|""|
 |PanelVariableResolution|PanelVariableResolution|1|1|
 ##
 

--- a/Material Scanner/SSC_Edition.yolol
+++ b/Material Scanner/SSC_Edition.yolol
@@ -1,10 +1,12 @@
-j="\nMat|Stacks" o=j a=" Ore" b="\n" d="♥" e="♡" h="ium" TO=20
-:autoscan-=s s=e :autoscan=s+:autoscan f=1728000 :Re=1 :L=0 goto2+:AS
-:autoscan-=s s=d :autoscan=s+:autoscan g="ite" i=0 :I=0 :L=1 :R=0 :S=1
-tv=0 o=j c=" Crystal" i++ if i>TO then :L=0 goto9 end goto5-:S
-:L=0 i/=:R :I=0 v=:V/f*1000 tv+=v o+=b+"① "+(:M-a-c-g-h)+"|"+v
-i/=:R :I=1 v=:V/f*1000 tv+=v o+=b+"② "+(:M-a-c-g-h)+"|"+v
-i/=:R v=tv at="\nCLass:"+(4+v>10+v>11+v>18+v>26+v>124+v>270)
-i/=:R :autoscan=s+o+b+"Total Stacks:"+tv+at :S=0 :Re=1 goto2+:AS
-w="\n !WARNING!" i/=:R :autoscan=s+w+"\n\n «TIMEOUT»\n"+w goto2+:AS
-:autoscan=s+w+"\n\n  Nothing\n   Found\n"+w goto2+:AS 
+j="\nMat|Stacks" o=j a=" Ore" b="\n" d="♥" e="♡" h="ium" TO=20 
+:scan-=s s=e :scan=s+:scan f=1728000 :Reset=1 :OL=0 goto2+:OT
+:scan-=s s=d :scan=s+:scan g="ite" i=0 :OI=0 :OL=1 :OR=0 
+:OS=1 tv=0 o=j c=" Crystal" i++ if i>TO then :OL=0 goto9 end goto5-:OS
+:OL=0 i/=:OR :OI=0 v=:OV/f*1000 tv+=v o+=b+"① "+(:OM-a-c-g-h)+"|"+v
+i/=:OR :OI=1 v=:OV/f*1000 tv+=v o+=b+"② "+(:OM-a-c-g-h)+"|"+v
+i/=:OR v=tv at="\nCLass:"+(4+v>10+v>11+v>18+v>26+v>124+v>270)
+i/=:OR :scan=s+o+b+"Total Stacks:"+tv+at :OS=0 :Reset=1 goto2+:OT
+w="\n !WARNING!" i/=:OR :scan=s+w+"\n\n «TIMEOUT»\n"+w goto2+:OT
+:scan=s+w+"\n\n  Nothing\n   Found\n"+w goto2+:OT 
+
+// https://github.com/DerPfandadler/Pfandadler-YOLOL

--- a/Material Scanner/SSC_Edition.yolol
+++ b/Material Scanner/SSC_Edition.yolol
@@ -1,12 +1,12 @@
 j="\nMat|Stacks" o=j a=" Ore" b="\n" d="♥" e="♡" h="ium" TO=20 
-:scan-=s s=e :scan=s+:scan f=1728000 :Reset=1 :OL=0 goto2+:OT
-:scan-=s s=d :scan=s+:scan g="ite" i=0 :OI=0 :OL=1 :OR=0 
+:scans-=s s=e :scans=s+:scans f=1728000 :Reset=1 :OL=0 goto2+:OT
+:scans-=s s=d :scans=s+:scans g="ite" i=0 :OI=0 :OL=1 :OX=0 
 :OS=1 tv=0 o=j c=" Crystal" i++ if i>TO then :OL=0 goto9 end goto5-:OS
-:OL=0 i/=:OR :OI=0 v=:OV/f*1000 tv+=v o+=b+"① "+(:OM-a-c-g-h)+"|"+v
-i/=:OR :OI=1 v=:OV/f*1000 tv+=v o+=b+"② "+(:OM-a-c-g-h)+"|"+v
-i/=:OR v=tv at="\nCLass:"+(4+v>10+v>11+v>18+v>26+v>124+v>270)
-i/=:OR :scan=s+o+b+"Total Stacks:"+tv+at :OS=0 :Reset=1 goto2+:OT
-w="\n !WARNING!" i/=:OR :scan=s+w+"\n\n «TIMEOUT»\n"+w goto2+:OT
-:scan=s+w+"\n\n  Nothing\n   Found\n"+w goto2+:OT 
+:OL=0 i/=:OX :OI=0 v=:OV/f*1000 tv+=v o+=b+"① "+(:OM-a-c-g-h)+"|"+v
+i/=:OX :OI=1 v=:OV/f*1000 tv+=v o+=b+"② "+(:OM-a-c-g-h)+"|"+v
+i/=:OX v=tv at="\nCLass:"+(4+v>10+v>11+v>18+v>26+v>124+v>270)
+i/=:OX :scans=s+o+b+"Total Stacks:"+tv+at :OS=0 :Reset=1 goto2+:OT
+w="\n !WARNING!" i/=:OX :scans=s+w+"\n\n «TIMEOUT»\n"+w goto2+:OT
+:scans=s+w+"\n\n  Nothing\n   Found\n"+w goto2+:OT 
 
 // https://github.com/DerPfandadler/Pfandadler-YOLOL


### PR DESCRIPTION
Hi,

as explained in issue #3 I went ahead and updated your script to work with 2 character variables.  I used the prefix `O` as it seems an uncommon prefix in most complex scripts I've seen, adjusted `:autoscan` to `:scan` to save on space and replaced `:Re` with `:Reset` so it doesn't need a custom name anymore.

I hope you like it! We in our Singularity company sure do ;-)